### PR TITLE
Fix collection inserted data not available bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@creately/rxdata",
-  "version": "5.0.1",
+  "version": "5.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creately/rxdata",
-  "version": "5.0.1",
+  "version": "5.1.1",
   "description": "",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/__tests__/collection.spec.ts
+++ b/src/__tests__/collection.spec.ts
@@ -98,7 +98,7 @@ describe('Collection', () => {
         const promise = watchN(col, 1);
         await col.insert(TEST_DOCS);
         const out = await promise;
-        expect(out).toEqual([{ type: 'insert', docs: [...TEST_DOCS] }]);
+        expect(out).toEqual([{ id: (jasmine.any(Number) as any) as number, type: 'insert', docs: [...TEST_DOCS] }]);
         done();
       });
 
@@ -107,7 +107,9 @@ describe('Collection', () => {
         const watchPromise = watchN(col, 1, { z: 3 });
         await col.insert(TEST_DOCS);
         const out = await watchPromise;
-        expect(out).toEqual([{ type: 'insert', docs: TEST_DOCS.filter(doc => doc.z === 3) }]);
+        expect(out).toEqual([
+          { id: (jasmine.any(Number) as any) as number, type: 'insert', docs: TEST_DOCS.filter(doc => doc.z === 3) },
+        ]);
         done();
       });
 
@@ -330,7 +332,7 @@ describe('Collection', () => {
       const promise = watchN(col, 1);
       await col.insert(TEST_DOCS);
       const out = await promise;
-      expect(out).toEqual([{ type: 'insert', docs: [...TEST_DOCS] }]);
+      expect(out).toEqual([{ id: (jasmine.any(Number) as any) as number, type: 'insert', docs: [...TEST_DOCS] }]);
       done();
     });
 
@@ -393,6 +395,7 @@ describe('Collection', () => {
       const out = await promise;
       expect(out).toEqual([
         {
+          id: (jasmine.any(Number) as any) as number,
           type: 'update',
           docs: [{ id: 'd113', x: 1, y: 1, z: 3, a: 1 }, { id: 'd123', x: 1, y: 2, z: 3, a: 1 }],
           modifier: { $set: { a: 1 } },
@@ -436,6 +439,7 @@ describe('Collection', () => {
       const out = await promise;
       expect(out).toEqual([
         {
+          id: (jasmine.any(Number) as any) as number,
           type: 'remove',
           docs: [{ id: 'd113', x: 1, y: 1, z: 3 }, { id: 'd123', x: 1, y: 2, z: 3 }],
         },


### PR DESCRIPTION
**Bug**

 - Create a new collection instance (can have documents in it)
 - Insert, update or remove some documents. Do not read data from it.
 - Immediately (on the same call stack) read data from the collection.

Changes made on step 2 will not be there on results. This only happens when the first operation made on the collection is an insert or an update and a read is performed immediately after that. There's a race condition so it may not happen all the time (can be recreated by adding a wait time inside apple method).

This happens because the insert operation attempts to read already available data from the indexed db and starts the `load` operation. This operation will return an empty array (before the read). If a find operation is started before load completes, it will also wait on the same promise created by the insert operation which emits an empty array.

**Fix**

- wait until changes are applied to the cache on insert/update/remove